### PR TITLE
Show music in search results

### DIFF
--- a/YoutubeScript.js
+++ b/YoutubeScript.js
@@ -3520,6 +3520,7 @@ function extractVideoRenderer_Video(videoRenderer, contextData) {
 		isLive = true;
 
 	if (!isLive && !videoRenderer.publishedTimeText?.simpleText) {
+		// Music videos have no dates in search results
 		videoRenderer.publishedTimeText = { simpleText: "" };
 	}
 

--- a/YoutubeScript.js
+++ b/YoutubeScript.js
@@ -3519,9 +3519,9 @@ function extractVideoRenderer_Video(videoRenderer, contextData) {
 	if(plannedDate)
 		isLive = true;
 
-	if(!isLive && !videoRenderer.publishedTimeText?.simpleText)
-		return  null; //Not a normal video
-
+	if (!isLive && !videoRenderer.publishedTimeText?.simpleText) {
+		videoRenderer.publishedTimeText = { simpleText: "" };
+	}
 
 
 	const author = (contextData && contextData.authorLink) ?


### PR DESCRIPTION
fixes futo-org/grayjay-android#1105
TLDR: Some music is auto-generated by youtube and the videos have to be handled slightly differently.

They have no date field
![youtube search results](https://github.com/futo-org/grayjay-plugin-youtube/assets/33258902/d16cf31c-ae53-4148-803c-577c3ce1ac9f)

The current plugin handles this by completely removing these videos from search results. My proposed solution replaces this field by an empty string, allowing them to show up.
![Screenshot_20240704-145151~2](https://github.com/futo-org/grayjay-plugin-youtube/assets/33258902/3c932e92-3025-41aa-a8a4-44f0377651e3)

This does have the drawback of showing an awkward "x views **⋅**" with nothing after the dot, but I could not find a way to have it display only the views without modifying grayjay itself.

Please let me know if there's anything that could be improved.