### PR TITLE
Add apiv3 URL pattern

### DIFF
--- a/YoutubeScript.js
+++ b/YoutubeScript.js
@@ -58,6 +58,7 @@ const REGEX_VIDEO_URL_SHARE_LIVE = new RegExp("https://(.*\\.)?youtube\\.com/liv
 const REGEX_VIDEO_URL_SHORT = new RegExp("https://(.*\\.)?youtube\\.com/shorts/(.*)");
 const REGEX_VIDEO_URL_CLIP = new RegExp("https://(.*\\.)?youtube\\.com/clip/(.*)[?]?");
 const REGEX_VIDEO_URL_EMBED = new RegExp("https://(.*\\.)?youtube\\.com/embed/([^?]+)");
+const REGEX_VIDEO_URL_APIv3 = new RegExp("https://(.*\\.)?youtube\\.com/v/(.*)\?version=3");
 
 const REGEX_VIDEO_CHANNEL_URL = new RegExp("https://(.*\\.)?youtube\\.com/channel/(.*)");
 const REGEX_VIDEO_CHANNEL_URL2 = new RegExp("https://(.*\\.)?youtube\\.com/user/.*");
@@ -381,7 +382,7 @@ source.getChannelTemplateByClaimMap = () => {
 
 //Video
 source.isContentDetailsUrl = (url) => {
-	return REGEX_VIDEO_URL_DESKTOP.test(url) || REGEX_VIDEO_URL_SHARE.test(url) || REGEX_VIDEO_URL_SHARE_LIVE.test(url) || REGEX_VIDEO_URL_SHORT.test(url) || REGEX_VIDEO_URL_CLIP.test(url) || REGEX_VIDEO_URL_EMBED.test(url);
+	return REGEX_VIDEO_URL_DESKTOP.test(url) || REGEX_VIDEO_URL_SHARE.test(url) || REGEX_VIDEO_URL_SHARE_LIVE.test(url) || REGEX_VIDEO_URL_SHORT.test(url) || REGEX_VIDEO_URL_CLIP.test(url) || REGEX_VIDEO_URL_EMBED.test(url) || REGEX_VIDEO_URL_APIv3.test(url);
 };
 
 
@@ -1934,6 +1935,10 @@ function extractVideoIDFromUrl(url) {
 		return removeQuery(match[2]);
 
 	match = url.match(REGEX_VIDEO_URL_SHORT);
+	if(match)
+		return removeQuery(match[2]);
+
+	match = url.match(REGEX_VIDEO_URL_APIv3);
 	if(match)
 		return removeQuery(match[2]);
 


### PR DESCRIPTION
This adds another URL pattern as described here:
https://developers.google.com/youtube/iframe_api_reference
![image](https://github.com/user-attachments/assets/abc6d7c8-c214-4e8a-912c-a24f588f9503)
It fixes https://github.com/futo-org/Grayjay.Desktop/issues/218