### PR TITLE
Fix access on null value in `extractPage_Tabs`

### DIFF
--- a/YoutubeScript.js
+++ b/YoutubeScript.js
@@ -3998,7 +3998,7 @@ function extractChannel_PlatformChannel(initialData, sourceUrl = null) {
  * @returns 
  */
 function extractPage_Tabs(initialData, contextData) {
-	const content = initialData.contents;
+	const content = initialData?.contents;
 	if(!content) {
 	    if(bridge.devSubmit) bridge.devSubmit("extractPage_Tabs - Missing contents", JSON.stringify(initialData));
 	    throw new ScriptException("Missing contents");


### PR DESCRIPTION
In `extractPage_Tabs`, the `initialData.contents` access causes the script to throw when `getHome` is called on a home refresh in Grayjay Desktop. See https://github.com/futo-org/Grayjay.Desktop/issues/354 for more info.

This PR makes a small change so the error message is more useful. It does not fix the root cause (yet).